### PR TITLE
Remove constraint on Ruby version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,5 @@
 source 'https://rubygems.org'
 
-ruby '2.2.2'
-
 gem 'rails', '4.1.8'
 gem 'mysql2'
 gem 'unicorn'


### PR DESCRIPTION
so that this will continue run with new Buildpacks as old Rubies are removed.

Ruby 2.2.2 is not supported by default on PWS right now, for example, as Ruby 2.2.2 was removed from the buildpack in 1.6.11, which was shipped on or around 2015-12-17.

Tagging @animatedmax 
