### PR TITLE
Lock ruby to 2.3.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,7 @@
 source 'https://rubygems.org'
 
+ruby '~> 2.3.0'
+
 gem 'rails', '4.1.8'
 gem 'mysql2'
 gem 'unicorn'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -90,4 +90,4 @@ DEPENDENCIES
   unicorn
 
 BUNDLED WITH
-   1.10.5
+   1.14.6


### PR DESCRIPTION
activesupport 4.1 requires json gem which does not work on ruby 2.4.x

[#145752155]

Signed-off-by: Dave Goddard <dave@goddard.id.au>